### PR TITLE
update to 5.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,9 @@ source:
   sha256: e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
 
 build:
-  number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
@@ -32,7 +32,13 @@ about:
   home: https://github.com/micheles/decorator
   license: BSD-2-Clause
   license_file: LICENSE.txt
-  summary: Decorators for Humans
+  summary: Better living through Python with decorators.
+  description: |
+    Preserve the signature of decorated functions in a consistent way
+    across Python releases.
+  doc_url: http://decorator.readthedocs.io/en/stable/
+  doc_source_url: https://github.com/micheles/decorator/tree/master/docs
+  dev_url: https://github.com/micheles/decorator
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.0.9" %}
+{% set version = "5.1.0" %}
 
 package:
   name: decorator
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/decorator/decorator-{{ version }}.tar.gz
-  sha256: 72ecfba4320a893c53f9706bebb2d55c270c1e51a28789361aa93e4a21319ed5
+  sha256: e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ about:
   description: |
     Preserve the signature of decorated functions in a consistent way
     across Python releases.
-  doc_url: http://decorator.readthedocs.io/en/stable/
+  doc_url: https://github.com/micheles/decorator/blob/master/docs/documentation.md
   doc_source_url: https://github.com/micheles/decorator/tree/master/docs
   dev_url: https://github.com/micheles/decorator
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,16 +9,16 @@ source:
   sha256: e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
   run:
-    - python >=3.5 
+    - python
 
 test:
   requires:
@@ -32,13 +32,7 @@ about:
   home: https://github.com/micheles/decorator
   license: BSD-2-Clause
   license_file: LICENSE.txt
-  summary: Better living through Python with decorators.
-  description: |
-    Preserve the signature of decorated functions in a consistent way
-    across Python releases.
-  doc_url: http://decorator.readthedocs.io/en/stable/
-  doc_source_url: https://github.com/micheles/decorator/tree/master/docs
-  dev_url: https://github.com/micheles/decorator
+  summary: Decorators for Humans
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
* [x] upstream repo https://github.com/micheles/decorator
* [x] run tests on dependent packages - built ipython
* [x] go through [changelog](https://github.com/micheles/decorator/blob/master/CHANGES.md) https://github.com/micheles/decorator/compare/5.0.9...5.1.0 (no 5.1.0 tag yet)
  * Added a function decoratorx using the FunctionMaker and thus preserving the signature of __code__ objects. Then fixed three small bugs:
    * Sphinx was printing a few warnings when building the documentation, as signaled by Tomasz Kłoczko
    * functions decorated with decorator.contextmanager were one-shot, as discovered by Alex Pizarro.
    * decorator.decorator was not passing the kwsyntax argument.
* [x] look for any open issues for new versions
* [x] dev_url, doc_url valid
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream github setup - python >= 3.5