### PR TITLE
Pin Python 3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
For what it's worth, the last release on this package broke one of our last 2.7 build.

Pinned to >=3.5 to reflect conda-forge (https://github.com/conda-forge/decorator-feedstock/blob/master/recipe/meta.yaml) itself a reflect of the `setup.py` of that package (https://github.com/micheles/decorator/blob/master/setup.py).
