### PR TITLE
decorator 5.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "decorator" %}
 {% set version = "5.1.1" %}
 
 package:
-  name: decorator
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/d/decorator/decorator-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/decorator-{{ version }}.tar.gz
   sha256: 637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330
 
 build:
@@ -33,13 +34,14 @@ test:
 about:
   home: https://github.com/micheles/decorator
   license: BSD-2-Clause
+  license_family: BSD
   license_file: LICENSE.txt
   summary: Better living through Python with decorators.
   description: |
     Preserve the signature of decorated functions in a consistent way
     across Python releases.
   doc_url: https://github.com/micheles/decorator/blob/master/docs/documentation.md
-  doc_source_url: https://github.com/micheles/decorator/tree/master/docs
+  doc_source_url: https://github.com/micheles/decorator/tree/{{ version }}/docs
   dev_url: https://github.com/micheles/decorator
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.1.0" %}
+{% set version = "5.1.1" %}
 
 package:
   name: decorator
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/decorator/decorator-{{ version }}.tar.gz
-  sha256: e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
+  sha256: 637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,12 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.5
 
 test:
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
   imports:


### PR DESCRIPTION
Update decorator to 5.1.1

Upstream changelog: https://github.com/micheles/decorator/blob/5.1.1/CHANGES.md
Bug tracker: https://github.com/micheles/decorator/issues
Upstream license: https://github.com/micheles/decorator/blob/5.1.1/LICENSE.txt
Upstream setup file: https://github.com/micheles/decorator/blob/5.1.1/setup.py

Actions:
1. Use jinja2 templates for package name and version
2. Update doc_source_url
3. Add license_family